### PR TITLE
Adding support for AWS_SESSION_TOKEN to Bedrock configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -142,6 +142,7 @@ OPENAI_COMPATIBLE_TOKEN=ollama
 # AWS credentials can be provided via environment variables or IAM roles
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
+AWS_SESSION_TOKEN=your-session-token
 AWS_DEFAULT_REGION=us-east-1
 # Bedrock model names - use full model identifiers
 BEDROCK_REASONING_MODEL=anthropic.claude-3-7-sonnet-20250219-v1:0

--- a/src/core/models/model_picker.py
+++ b/src/core/models/model_picker.py
@@ -266,9 +266,17 @@ class ModelConfig:
             region_name = os.getenv('AWS_DEFAULT_REGION', 'us-east-1')
             aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
             aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+            aws_session_token = os.getenv('AWS_SESSION_TOKEN')
             
             # Create provider with credentials if provided, otherwise use default AWS credential chain
-            if aws_access_key_id and aws_secret_access_key:
+            if aws_access_key_id and aws_secret_access_key and aws_session_token:
+                bedrock_provider = BedrockProvider(
+                    region_name=region_name,
+                    aws_access_key_id=aws_access_key_id,
+                    aws_secret_access_key=aws_secret_access_key,
+                    aws_session_token=aws_session_token
+                )
+            elif aws_access_key_id and aws_secret_access_key:
                 bedrock_provider = BedrockProvider(
                     region_name=region_name,
                     aws_access_key_id=aws_access_key_id,


### PR DESCRIPTION
Simple update to allow optional use of AWS_SESSION_TOKEN in the AWS Bedrock provider configuration section